### PR TITLE
Fix missing `state` keyword in the docs

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -499,7 +499,7 @@ machine light {
 }
 
 machine main {
-  idle {
+  state idle {
     invoke light {
       done => idle
     }


### PR DESCRIPTION
```diff
machine main {
-  idle {
+ state idle {
    invoke light {
      done => idle
    }
  }
}
```