### PR TITLE
Update install documentation

### DIFF
--- a/install.md
+++ b/install.md
@@ -93,5 +93,3 @@ export default {
   ]
 }
 ```
-
-*test*


### PR DESCRIPTION
Remove a rogue "*test*" word at the end of the install page.